### PR TITLE
fix(draws): insert inline ads every 10 items

### DIFF
--- a/app/components/LottoDrawList/index.tsx
+++ b/app/components/LottoDrawList/index.tsx
@@ -5,6 +5,7 @@ import { FC, useEffect } from "react";
 import { useMediaQuery } from "react-responsive";
 import { fetchDraws } from "~/api/lucktteryApi/api";
 import { CursorPage, LottoDrawResponse } from "~/api/lucktteryApi/types";
+import GoogleAdSense from "../GoogleAdSense";
 import LottoDraw from "../LottoDraw";
 import LottoDrawSkeleton from "../LottoDraw/Skeleton";
 import styles from "./styles.module.scss";
@@ -12,6 +13,22 @@ import styles from "./styles.module.scss";
 type LottoDrawListProps = {
   limit: number
 }
+
+const AD_FREQUENCY = 10;
+const AD_SLOT = "9394671723";
+const AD_ROW_HEIGHT = 140;
+
+const getAdCount = (drawCount: number) => Math.floor(Math.max(drawCount - 1, 0) / AD_FREQUENCY);
+
+const getVirtualRowCount = (drawCount: number) => drawCount + getAdCount(drawCount);
+
+const isAdRow = (virtualIndex: number) => (virtualIndex + 1) % (AD_FREQUENCY + 1) === 0;
+
+const getDrawIndexFromVirtualIndex = (virtualIndex: number) => {
+  const adRowsBefore = Math.floor((virtualIndex + 1) / (AD_FREQUENCY + 1));
+
+  return virtualIndex - adRowsBefore;
+};
 
 export const LottoDrawList: FC<LottoDrawListProps> = ({ limit }) => {
   const isMobile = useMediaQuery({ maxWidth: 768 });
@@ -35,40 +52,44 @@ export const LottoDrawList: FC<LottoDrawListProps> = ({ limit }) => {
 
   const totalCount = data?.pages?.at(0)?.total_count ?? 0;
   const allContents = data?.pages.flatMap((page) => page.contents) ?? [];
-  const estimateSize = isMobile ? 250 : 180;
+  const drawEstimateSize = isMobile ? 250 : 180;
+  const virtualRowCount = getVirtualRowCount(totalCount);
 
   const rowVirtualizer = useWindowVirtualizer({
-    count: totalCount,
-    estimateSize: () => estimateSize,
+    count: virtualRowCount,
+    estimateSize: (index) => isAdRow(index) ? AD_ROW_HEIGHT : drawEstimateSize,
     measureElement: (el) => el.getBoundingClientRect().height,
-    initialRect: { width: 0, height: estimateSize * limit },
+    initialRect: { width: 0, height: drawEstimateSize * limit },
     gap: 16,
     overscan: 10,
   });
+  const virtualItems = rowVirtualizer.getVirtualItems();
 
   useEffect(() => {
     rowVirtualizer.measure()
-  }, [isMobile]);
+  }, [isMobile, rowVirtualizer]);
 
   useEffect(() => {
-    const virtualItems = rowVirtualizer.getVirtualItems();
-
     if (!virtualItems.length) return;
 
-    const lastItem = virtualItems[virtualItems.length - 1];
+    const lastDrawItem = [...virtualItems].reverse().find((item) => !isAdRow(item.index));
+
+    if (!lastDrawItem) return;
 
     if (
-      lastItem.index >= allContents.length - 1 &&
+      getDrawIndexFromVirtualIndex(lastDrawItem.index) >= allContents.length - 1 &&
       hasNextPage &&
       !isFetchingNextPage
     ) {
       fetchNextPage();
     }
   }, [
-    rowVirtualizer.getVirtualItems(),
+    allContents.length,
     hasNextPage,
     isFetchingNextPage,
     fetchNextPage,
+    rowVirtualizer,
+    virtualItems,
   ]);
 
   return (
@@ -78,8 +99,10 @@ export const LottoDrawList: FC<LottoDrawListProps> = ({ limit }) => {
         height: rowVirtualizer.getTotalSize(),
       }}
     >
-      {rowVirtualizer.getVirtualItems().map((virtualRow) => {
-        const content = allContents[virtualRow.index]
+      {virtualItems.map((virtualRow) => {
+        const adRow = isAdRow(virtualRow.index);
+        const drawIndex = getDrawIndexFromVirtualIndex(virtualRow.index);
+        const content = allContents[drawIndex];
 
         return (
           <div
@@ -92,8 +115,19 @@ export const LottoDrawList: FC<LottoDrawListProps> = ({ limit }) => {
               transform: `translateY(${virtualRow.start}px)`,
             }}
             data-index={virtualRow.index}
+            ref={rowVirtualizer.measureElement}
           >
-            {content ? (
+            {adRow ? (
+              <div className={styles.adContainer}>
+                <GoogleAdSense
+                  className={styles.ad}
+                  slot={AD_SLOT}
+                  format="auto"
+                  responsive="true"
+                  style={{ width: "100%", height: `${AD_ROW_HEIGHT}px` }}
+                />
+              </div>
+            ) : content ? (
               <Link className={styles.link} to={`/draws/${content.draw}`}>
                 <LottoDraw {...content} />
               </Link>

--- a/app/components/LottoDrawList/styles.module.scss
+++ b/app/components/LottoDrawList/styles.module.scss
@@ -15,3 +15,22 @@
     transform: translateY(-2px);
   }
 }
+
+.adContainer {
+  width: 100%;
+  max-width: 100%;
+  min-width: 0;
+  padding: 8px 0;
+  overflow: hidden;
+  box-sizing: border-box;
+}
+
+.ad {
+  display: block;
+  width: 100%;
+  max-width: 100%;
+  min-width: 0;
+  height: 140px;
+  overflow: hidden;
+  box-sizing: border-box;
+}


### PR DESCRIPTION
## Summary
- insert inline AdSense blocks into the virtualized draws list every 10 items
- keep
  inline ad rows at a fixed height and prevent horizontal overflow
- preserve infinite scrolling by mapping virtual
  rows back to draw entries

## Testing
- pnpm typecheck
- pnpm lint