### PR TITLE
fix(ci): update publish workflow for pnpm

### DIFF
--- a/.github/workflows/publish.yml
+++ b/.github/workflows/publish.yml
@@ -12,17 +12,23 @@ jobs:
       - name: Checkout repository
         uses: actions/checkout@v4
 
+      - name: Set up pnpm
+        uses: pnpm/action-setup@v4
+        with:
+          version: 10.10.0
+          run_install: false
+
       - name: Set up Node.js
         uses: actions/setup-node@v4
         with:
           node-version: 20
-          cache: 'npm'
+          cache: 'pnpm'
 
       - name: Install dependencies
-        run: npm install
+        run: pnpm install --frozen-lockfile
 
       - name: Build Remix app
-        run: npm run build
+        run: pnpm run build
 
       - name: Publish
         uses: netlify/actions/cli@master


### PR DESCRIPTION
## Summary
  - switch publish workflow cache from npm to pnpm
  - install dependencies with pnpm --frozen-lockfile
  - build with pnpm run build

  ## Why
  The publish workflow was still configured for npm after the repository migrated to pnpm, so setup-node could not find a
  supported lockfile.